### PR TITLE
Use live option chains with scheduler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,98 @@
-git init
-git add .
-git commit -m "Initial commit"
-git branch -M main
-git remote add origin https://github.com/<you>/<repo>.git
-git push -u origin main
+# Options Trader
+
+An automated toolkit for evaluating a synthetic long underlying strategy (buy 1 call, sell 2 puts) on a basket of high-conviction stocks. The project downloads live option chains from Yahoo Finance, computes structure cashflows using quoted premiums, and highlights the best opportunities based on annualized yield and capital at risk.
+
+## Features
+
+- Download spot data and live option chains via [yfinance](https://github.com/ranaroussi/yfinance)
+- Evaluate quoted premiums directly (no synthetic pricing) for ATM calls and configurable put-strike adjustments around 90% of spot
+- Focus on expiries between 3 and 9 months (configurable) and automatically pick the closest available contracts
+- Compute key metrics for the 1 call : 2 put structure:
+  - Time to expiry (days and years)
+  - Call/put premiums (per share and per structure)
+  - Net premium, capital at risk, breakeven, and effective entry price
+  - Annualized yield using actual cashflows
+  - Implied volatility derived from the quoted contracts (with configurable bounds)
+- Automatic mode surfaces the best trade per ticker while manual mode prints all qualifying expiries
+- Optional daily scheduler to run scans at a specific local time (4:30 pm GST by default)
+- Configurable via CLI flags or YAML configuration file
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[full]
+```
+
+This project relies on third-party packages for data access and configuration parsing:
+
+- [`yfinance`](https://github.com/ranaroussi/yfinance) (pulls market data; installs `pandas`/`numpy`)
+- [`PyYAML`](https://pyyaml.org/) (parses YAML configuration files)
+
+## Usage
+
+### Automatic mode
+
+Provide tickers directly (defaults to Apple, Microsoft, Google, and Meta):
+
+```bash
+python -m options_trader --tickers AAPL MSFT NVDA
+```
+
+Use a configuration file:
+
+```bash
+python -m options_trader --config configs/sample.yaml
+```
+
+### Manual mode
+
+Manual mode prints all qualifying expiries (3–9 months by default):
+
+```bash
+python -m options_trader --mode manual --tickers AAPL MSFT
+```
+
+Limit output to the top N opportunities (automatic mode):
+
+```bash
+python -m options_trader --tickers AAPL MSFT NVDA --top 5
+```
+
+### Customising parameters
+
+CLI flags override defaults:
+
+```bash
+python -m options_trader \
+  --tickers AAPL \
+  --put-strike-pct 0.9 \
+  --put-variation -0.05 0 0.05 \
+  --call-strike-pct 1.0 \
+  --min-days 120 \
+  --max-days 240 \
+  --risk-free-rate 0.045
+```
+
+### Daily automation (4:30 pm GST example)
+
+The CLI can run automatically each day at a fixed time in a chosen timezone. For the requested 4:30 pm Gulf Standard Time schedule:
+
+```bash
+python -m options_trader --tickers AAPL MSFT GOOGL META --schedule-time 16:30 --timezone Asia/Dubai
+```
+
+The process waits until the next scheduled window, runs the scan, prints the results, and repeats every 24 hours. Press `Ctrl+C` to stop the scheduler.
+
+## Testing
+
+```bash
+pytest
+```
+
+## Notes
+
+- The engine requires network access to download data from Yahoo Finance. For offline usage, substitute the `MarketDataClient` and `OptionChainClient` with versions that source data locally.
+- Notifications default to stdout; integrate your own notifier by implementing the `Notifier` protocol.
+- Premiums printed in reports represent both per-share quotes and the total cash flow for the entire structure (contract size × number of contracts).

--- a/configs/sample.yaml
+++ b/configs/sample.yaml
@@ -1,0 +1,19 @@
+# Example configuration for the options trader engine
+# Values below reflect the synthetic long structure: buy 1 call, sell 2 puts.
+tickers:
+  - AAPL
+  - MSFT
+  - GOOGL
+  - META
+mode: automatic
+risk_free_rate: 0.04
+put_strike_pct: 0.9
+call_strike_pct: 1.0
+min_days: 90
+max_days: 270
+expiry_step: 30
+call_to_put_ratio: [1, 2]
+contract_size: 100
+min_volatility: 0.1
+max_volatility: 1.0
+put_strike_variation: [-0.05, 0.0, 0.05]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "options-trader"
+version = "0.1.0"
+description = "Automated synthetic long option strategy evaluator"
+readme = "README.md"
+authors = [{name = "Option Automation"}]
+requires-python = ">=3.10"
+dependencies = ["yfinance>=0.2.31"]
+
+[project.scripts]
+options-trader = "options_trader.cli:main"
+
+[project.optional-dependencies]
+config = ["pyyaml>=6.0"]
+full = ["pyyaml>=6.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/options_trader/__init__.py
+++ b/src/options_trader/__init__.py
@@ -1,0 +1,11 @@
+"""Options trader package for evaluating synthetic long strategies."""
+
+from .config import StrategyConfig, load_config
+from .strategy import StrategyEngine, StrategyParameters
+
+__all__ = [
+    "StrategyConfig",
+    "StrategyEngine",
+    "StrategyParameters",
+    "load_config",
+]

--- a/src/options_trader/__main__.py
+++ b/src/options_trader/__main__.py
@@ -1,0 +1,5 @@
+"""Module entry point."""
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover - module entry
+    raise SystemExit(main())

--- a/src/options_trader/cli.py
+++ b/src/options_trader/cli.py
@@ -1,0 +1,183 @@
+"""Command line interface for the options trader."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, time as dt_time, timedelta
+import time as time_module
+from typing import List, Sequence
+
+from zoneinfo import ZoneInfo
+
+from .config import load_config
+from .reporting import summarize_results
+from .strategy import StrategyEngine, StrategyParameters
+
+
+DEFAULT_TICKERS = ["AAPL", "MSFT", "GOOGL", "META"]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Synthetic long options strategy helper")
+    parser.add_argument("--tickers", nargs="*", help="Tickers to evaluate", default=None)
+    parser.add_argument("--config", help="Path to YAML configuration file", default=None)
+    parser.add_argument(
+        "--mode",
+        choices=["automatic", "manual"],
+        default="automatic",
+        help="Automatic mode reports best trade per ticker; manual prints all expiries.",
+    )
+    parser.add_argument("--risk-free-rate", type=float, default=None)
+    parser.add_argument("--put-strike-pct", type=float, default=None)
+    parser.add_argument("--call-strike-pct", type=float, default=None)
+    parser.add_argument(
+        "--put-variation",
+        type=float,
+        nargs="*",
+        default=None,
+        help="Relative adjustments to apply to the base put strike percentage (e.g. -0.05 0 0.05)",
+    )
+    parser.add_argument("--min-days", type=int, default=None)
+    parser.add_argument("--max-days", type=int, default=None)
+    parser.add_argument("--expiry-step", type=int, default=30)
+    parser.add_argument("--top", type=int, default=3, help="Number of top results to print in automatic mode")
+    parser.add_argument(
+        "--schedule-time",
+        type=_parse_daily_time,
+        help="Schedule the scan to run daily at HH:MM (24h clock) in the selected timezone.",
+    )
+    parser.add_argument(
+        "--timezone",
+        default="Asia/Dubai",
+        help=(
+            "IANA timezone name used for scheduled runs. Default aligns with Gulf Standard Time (Asia/Dubai)."
+        ),
+    )
+    return parser
+
+
+def _parse_daily_time(value: str) -> dt_time:
+    try:
+        parsed = datetime.strptime(value, "%H:%M")
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("Time must be in HH:MM 24-hour format.") from exc
+    return parsed.time()
+
+
+def _params_from_args(args: argparse.Namespace, base: StrategyParameters) -> StrategyParameters:
+    return StrategyParameters(
+        put_strike_pct=args.put_strike_pct or base.put_strike_pct,
+        call_strike_pct=args.call_strike_pct or base.call_strike_pct,
+        min_days=args.min_days or base.min_days,
+        max_days=args.max_days or base.max_days,
+        expiry_step=args.expiry_step or base.expiry_step,
+        call_contracts=base.call_contracts,
+        put_contracts=base.put_contracts,
+        risk_free_rate=args.risk_free_rate or base.risk_free_rate,
+        min_volatility=base.min_volatility,
+        max_volatility=base.max_volatility,
+        put_strike_variation=tuple(args.put_variation) if args.put_variation else base.put_strike_variation,
+    )
+
+
+def _run_once(
+    engine: StrategyEngine,
+    tickers: Sequence[str],
+    params: StrategyParameters,
+    mode: str,
+    top: int,
+) -> None:
+    if mode == "manual":
+        for ticker in tickers:
+            results = engine.evaluate(ticker, params)
+            print(f"\n{ticker} - showing all qualifying expiries")
+            print("-" * 80)
+            if not results:
+                print("No results.")
+                continue
+            print(summarize_results(results))
+    else:
+        results = []
+        for ticker in tickers:
+            best = engine.best_result(ticker, params)
+            if best:
+                results.append(best)
+        if not results:
+            print("No qualifying trades found.")
+        for result in results[:top]:
+            print(summarize_results([result]))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    engine = StrategyEngine()
+    params = engine.parameters
+
+    tickers: List[str]
+    if args.config:
+        config = load_config(args.config)
+        tickers = config.normalized_tickers()
+        params = StrategyParameters(
+            put_strike_pct=config.put_strike_pct,
+            call_strike_pct=config.call_strike_pct,
+            min_days=config.min_days,
+            max_days=config.max_days,
+            call_contracts=config.call_to_put_ratio[0],
+            put_contracts=config.call_to_put_ratio[1],
+            risk_free_rate=config.risk_free_rate,
+            expiry_step=config.expiry_step,
+            contract_size=config.contract_size,
+            min_volatility=config.min_volatility,
+            max_volatility=config.max_volatility,
+            put_strike_variation=tuple(config.put_strike_variation),
+        )
+    else:
+        tickers = [t.upper() for t in (args.tickers or DEFAULT_TICKERS)]
+        params = _params_from_args(args, params)
+
+    engine = StrategyEngine(parameters=params)
+
+    if args.schedule_time:
+        try:
+            tz = ZoneInfo(args.timezone)
+        except Exception as exc:  # pragma: no cover - invalid tz guard
+            raise SystemExit(f"Invalid timezone '{args.timezone}': {exc}") from exc
+
+        schedule_time: dt_time = args.schedule_time
+        print(
+            f"Scheduling daily run for {schedule_time.strftime('%H:%M')} in timezone {args.timezone}."
+        )
+
+        while True:
+            now = datetime.now(tz)
+            run_at = datetime.combine(now.date(), schedule_time, tzinfo=tz)
+            if run_at <= now:
+                run_at += timedelta(days=1)
+            wait_seconds = max(0, (run_at - now).total_seconds())
+            hours, remainder = divmod(wait_seconds, 3600)
+            minutes = remainder // 60
+            print(
+                f"Next run at {run_at.isoformat(timespec='minutes')} (in {int(hours)}h{int(minutes)}m)."
+            )
+            try:
+                time_module.sleep(wait_seconds)
+            except KeyboardInterrupt:
+                print("Scheduler interrupted before execution.")
+                return 0
+
+            try:
+                _run_once(engine, tickers, params, args.mode, args.top)
+            except KeyboardInterrupt:
+                print("Scheduler interrupted during execution.")
+                return 0
+            except Exception as exc:  # pragma: no cover - defensive logging
+                print(f"Scheduled run failed: {exc}")
+    else:
+        _run_once(engine, tickers, params, args.mode, args.top)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    raise SystemExit(main())

--- a/src/options_trader/config.py
+++ b/src/options_trader/config.py
@@ -1,0 +1,40 @@
+"""Configuration helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Sequence
+
+try:  # pragma: no cover - optional dependency
+    import yaml
+except ImportError:  # pragma: no cover - optional dependency
+    yaml = None
+
+
+@dataclass
+class StrategyConfig:
+    tickers: List[str]
+    mode: str = "automatic"
+    risk_free_rate: float = 0.04
+    put_strike_pct: float = 0.9
+    call_strike_pct: float = 1.0
+    min_days: int = 90
+    max_days: int = 270
+    expiry_step: int = 30
+    call_to_put_ratio: Sequence[int] = (1, 2)
+    contract_size: int = 100
+    max_strikes: int = 6
+    min_volatility: float = 0.1
+    max_volatility: float = 1.0
+    put_strike_variation: Sequence[float] = (-0.05, 0.0, 0.05)
+
+    def normalized_tickers(self) -> List[str]:
+        return sorted({t.upper().strip() for t in self.tickers if t})
+
+
+def load_config(path: str | Path) -> StrategyConfig:
+    if yaml is None:  # pragma: no cover - optional dependency
+        raise ImportError("PyYAML is required to load configuration files. Install via 'pip install pyyaml'.")
+    with Path(path).open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    return StrategyConfig(**data)

--- a/src/options_trader/data.py
+++ b/src/options_trader/data.py
@@ -1,0 +1,189 @@
+"""Data access helpers for spot and option chain information."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, List, Sequence
+
+
+def _clean_number(value: float | int | None) -> float | None:
+    """Normalise numbers from pandas/numpy into Python floats."""
+
+    if value is None:
+        return None
+    try:
+        if math.isnan(value):  # type: ignore[arg-type]
+            return None
+    except TypeError:
+        pass
+    return float(value)
+
+
+@dataclass(frozen=True)
+class MarketData:
+    """Container for market data required by the pricing engine."""
+
+    ticker: str
+    spot_price: float
+    valuation_date: datetime
+    historical_prices: Sequence[float]
+
+    @property
+    def last_price(self) -> float:
+        if not self.historical_prices:
+            raise ValueError("Historical prices series is empty.")
+        return float(self.historical_prices[-1])
+
+
+@dataclass(frozen=True)
+class OptionQuote:
+    """Single option quote for a given strike and expiry."""
+
+    ticker: str
+    expiry: datetime
+    strike: float
+    option_type: str
+    bid: float | None
+    ask: float | None
+    last_price: float | None
+    implied_volatility: float | None
+
+    @property
+    def mid_price(self) -> float | None:
+        if self.bid is None or self.ask is None:
+            return None
+        if self.bid <= 0 or self.ask <= 0:
+            return None
+        return (self.bid + self.ask) / 2
+
+    @property
+    def price_per_share(self) -> float:
+        for value in (self.mid_price, self.last_price, self.bid, self.ask):
+            if value is not None and value > 0:
+                return float(value)
+        return 0.0
+
+
+@dataclass(frozen=True)
+class OptionChainSlice:
+    """Collections of call and put quotes for a specific expiry."""
+
+    ticker: str
+    expiry: datetime
+    calls: Sequence[OptionQuote]
+    puts: Sequence[OptionQuote]
+
+
+class MarketDataClient:
+    """Wrapper around yfinance spot and historical downloads."""
+
+    def __init__(self, period: str = "6mo", interval: str = "1d") -> None:
+        self.period = period
+        self.interval = interval
+
+    def _load_ticker(self, ticker: str):
+        try:
+            import yfinance as yf
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise ImportError(
+                "yfinance is required to download market data. Install via 'pip install yfinance'."
+            ) from exc
+
+        return yf.Ticker(ticker)
+
+    def fetch(self, ticker: str) -> MarketData:
+        ticker = ticker.upper().strip()
+        yf_ticker = self._load_ticker(ticker)
+        hist = yf_ticker.history(period=self.period, interval=self.interval)
+        if hist.empty:
+            raise ValueError(f"No historical data returned for {ticker}.")
+        close = hist["Close"].dropna()
+        if close.empty:
+            raise ValueError(f"Close prices missing for {ticker}.")
+        prices = [float(price) for price in close.tolist()]
+        spot_price = prices[-1]
+        valuation_date = datetime.now(timezone.utc)
+        return MarketData(
+            ticker=ticker,
+            spot_price=spot_price,
+            valuation_date=valuation_date,
+            historical_prices=prices,
+        )
+
+    def fetch_latest_price(self, ticker: str) -> float:
+        data = self.fetch(ticker)
+        return data.spot_price
+
+    def fetch_historical_prices(self, ticker: str) -> Sequence[float]:
+        data = self.fetch(ticker)
+        return data.historical_prices
+
+
+class OptionChainClient:
+    """Access to Yahoo Finance option chains."""
+
+    def __init__(self) -> None:
+        self._ticker_cache: dict[str, object] = {}
+
+    def _load_ticker(self, ticker: str):
+        try:
+            import yfinance as yf
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise ImportError(
+                "yfinance is required to download option data. Install via 'pip install yfinance'."
+            ) from exc
+
+        ticker = ticker.upper().strip()
+        cached = self._ticker_cache.get(ticker)
+        if cached is not None:
+            return cached
+        yf_ticker = yf.Ticker(ticker)
+        self._ticker_cache[ticker] = yf_ticker
+        return yf_ticker
+
+    @staticmethod
+    def _parse_expiry(expiry: str) -> datetime:
+        return datetime.strptime(expiry, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+
+    def list_expiries(self, ticker: str) -> List[datetime]:
+        yf_ticker = self._load_ticker(ticker)
+        expiries = getattr(yf_ticker, "options", [])
+        return [self._parse_expiry(expiry) for expiry in expiries]
+
+    def _build_quotes(
+        self, ticker: str, expiry: datetime, rows: Iterable[dict], option_type: str
+    ) -> List[OptionQuote]:
+        quotes: List[OptionQuote] = []
+        for row in rows:
+            strike = _clean_number(row.get("strike"))
+            if strike is None:
+                continue
+            quote = OptionQuote(
+                ticker=ticker,
+                expiry=expiry,
+                strike=strike,
+                option_type=option_type,
+                bid=_clean_number(row.get("bid")),
+                ask=_clean_number(row.get("ask")),
+                last_price=_clean_number(row.get("lastPrice")),
+                implied_volatility=_clean_number(row.get("impliedVolatility")),
+            )
+            quotes.append(quote)
+        return quotes
+
+    def fetch_chain(self, ticker: str, expiry: datetime | str) -> OptionChainSlice:
+        yf_ticker = self._load_ticker(ticker)
+        if isinstance(expiry, datetime):
+            expiry_dt = expiry
+            expiry_str = expiry.strftime("%Y-%m-%d")
+        else:
+            expiry_str = expiry
+            expiry_dt = self._parse_expiry(expiry)
+
+        chain = yf_ticker.option_chain(expiry_str)
+        call_rows = chain.calls.to_dict("records")
+        put_rows = chain.puts.to_dict("records")
+        calls = self._build_quotes(ticker, expiry_dt, call_rows, "call")
+        puts = self._build_quotes(ticker, expiry_dt, put_rows, "put")
+        return OptionChainSlice(ticker=ticker, expiry=expiry_dt, calls=calls, puts=puts)

--- a/src/options_trader/notifications.py
+++ b/src/options_trader/notifications.py
@@ -1,0 +1,20 @@
+"""Notification hooks."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class Notifier(Protocol):
+    """Protocol for sending notifications."""
+
+    def notify(self, message: str) -> None:  # pragma: no cover - interface
+        ...
+
+
+@dataclass
+class ConsoleNotifier:
+    prefix: str = "[OptionsTrader]"
+
+    def notify(self, message: str) -> None:
+        print(f"{self.prefix} {message}")

--- a/src/options_trader/pricing.py
+++ b/src/options_trader/pricing.py
@@ -1,0 +1,55 @@
+"""Black-Scholes pricing utilities."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class OptionPremium:
+    call: float
+    put: float
+
+
+def _norm_cdf(x: float) -> float:
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+def _d1(spot: float, strike: float, time: float, rate: float, volatility: float) -> float:
+    if spot <= 0 or strike <= 0:
+        raise ValueError("Spot and strike must be positive numbers.")
+    if time <= 0:
+        raise ValueError("Time to expiry must be positive in years.")
+    if volatility <= 0:
+        raise ValueError("Volatility must be positive (annualized decimal).")
+    numerator = math.log(spot / strike) + (rate + 0.5 * volatility**2) * time
+    denominator = volatility * math.sqrt(time)
+    return numerator / denominator
+
+
+def _d2(d1: float, time: float, volatility: float) -> float:
+    return d1 - volatility * math.sqrt(time)
+
+
+def black_scholes_premium(
+    spot: float,
+    strike: float,
+    time: float,
+    rate: float,
+    volatility: float,
+) -> OptionPremium:
+    """Return call and put prices using the Black-Scholes model."""
+
+    d1 = _d1(spot, strike, time, rate, volatility)
+    d2 = _d2(d1, time, volatility)
+    call = spot * _norm_cdf(d1) - strike * math.exp(-rate * time) * _norm_cdf(d2)
+    put = strike * math.exp(-rate * time) * _norm_cdf(-d2) - spot * _norm_cdf(-d1)
+    return OptionPremium(call=call, put=put)
+
+
+def intrinsic_value_call(spot: float, strike: float) -> float:
+    return max(0.0, spot - strike)
+
+
+def intrinsic_value_put(spot: float, strike: float) -> float:
+    return max(0.0, strike - spot)

--- a/src/options_trader/reporting.py
+++ b/src/options_trader/reporting.py
@@ -1,0 +1,57 @@
+"""Human readable reporting helpers."""
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .strategy import StrategyResult
+
+
+def format_currency(value: float) -> str:
+    return f"${value:,.2f}"
+
+
+def format_percentage(value: float) -> str:
+    return f"{value * 100:.2f}%"
+
+
+def format_optional_currency(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return format_currency(value)
+
+
+def format_optional_percentage(value: float | None) -> str:
+    if value is None:
+        return "N/A"
+    return format_percentage(value)
+
+
+def summarize_results(results: Iterable[StrategyResult]) -> str:
+    lines: List[str] = []
+    for result in results:
+        lines.append(
+            " | ".join(
+                [
+                    f"Ticker: {result.ticker}",
+                    f"Spot: {format_currency(result.spot_price)}",
+                    f"Valuation: {result.valuation_time.isoformat(timespec='minutes')}",
+                    f"Expiry: {result.expiry.date()} ({result.days_to_expiry} days / {result.years_to_expiry:.2f}y)",
+                    f"Call Strike: {format_currency(result.call_strike)}",
+                    f"Put Strike: {format_currency(result.put_strike)}",
+                    f"Call % Spot: {format_percentage(result.call_strike_pct)}",
+                    f"Put % Spot: {format_percentage(result.put_strike_pct)}",
+                    f"Structure: {result.call_contracts}C/{result.put_contracts}P @ {result.contract_size} shares",
+                    f"Call Premium (per share/total): {format_currency(result.call_price_per_share)} / {format_currency(result.call_premium)}",
+                    f"Put Premium (per share/total): {format_currency(result.put_price_per_share)} / {format_currency(result.put_premium)}",
+                    f"Net Premium: {format_currency(result.net_premium)}",
+                    f"Capital At Risk: {format_currency(result.capital_at_risk)}",
+                    f"Annualized Yield: {format_percentage(result.annualized_yield)}",
+                    f"Implied Volatility: {format_optional_percentage(result.implied_volatility)}",
+                    f"Breakeven: {format_currency(result.breakeven_price)}",
+                    f"Effective Entry: {format_currency(result.effective_entry_price)}",
+                    f"Call Bid/Ask: {format_optional_currency(result.call_bid)} / {format_optional_currency(result.call_ask)}",
+                    f"Put Bid/Ask: {format_optional_currency(result.put_bid)} / {format_optional_currency(result.put_ask)}",
+                ]
+            )
+        )
+    return "\n".join(lines)

--- a/src/options_trader/strategy.py
+++ b/src/options_trader/strategy.py
@@ -1,0 +1,266 @@
+"""Synthetic long strategy implementation using live option quotes."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Sequence
+
+from .config import StrategyConfig
+from .data import MarketDataClient, OptionChainClient, OptionQuote
+from .notifications import ConsoleNotifier, Notifier
+
+
+@dataclass(frozen=True)
+class StrategyParameters:
+    put_strike_pct: float = 0.9
+    call_strike_pct: float = 1.0
+    min_days: int = 90
+    max_days: int = 270
+    expiry_step: int = 30
+    call_contracts: int = 1
+    put_contracts: int = 2
+    contract_size: int = 100
+    risk_free_rate: float = 0.04
+    min_volatility: float = 0.05
+    max_volatility: float = 1.5
+    put_strike_variation: Sequence[float] = (-0.05, 0.0, 0.05)
+
+
+@dataclass(frozen=True)
+class StrategyResult:
+    ticker: str
+    valuation_time: datetime
+    expiry: datetime
+    days_to_expiry: int
+    call_strike: float
+    put_strike: float
+    call_strike_pct: float
+    put_strike_pct: float
+    call_price_per_share: float
+    put_price_per_share: float
+    call_premium: float
+    put_premium: float
+    net_premium: float
+    annualized_yield: float
+    implied_volatility: float | None
+    spot_price: float
+    breakeven_price: float
+    effective_entry_price: float
+    capital_at_risk: float
+    call_contracts: int
+    put_contracts: int
+    contract_size: int
+    call_quote: OptionQuote
+    put_quote: OptionQuote
+
+    @property
+    def description(self) -> str:
+        return (
+            f"Buy {self.call_contracts}x {self.call_strike:.2f} call, "
+            f"sell {self.put_contracts}x {self.put_strike:.2f} put "
+            f"(contract size {self.contract_size}) expiring {self.expiry.date()}"
+        )
+
+    @property
+    def years_to_expiry(self) -> float:
+        return self.days_to_expiry / 365.0
+
+    @property
+    def call_bid(self) -> float | None:
+        return self.call_quote.bid
+
+    @property
+    def call_ask(self) -> float | None:
+        return self.call_quote.ask
+
+    @property
+    def call_last(self) -> float | None:
+        return self.call_quote.last_price
+
+    @property
+    def call_mid(self) -> float | None:
+        return self.call_quote.mid_price
+
+    @property
+    def put_bid(self) -> float | None:
+        return self.put_quote.bid
+
+    @property
+    def put_ask(self) -> float | None:
+        return self.put_quote.ask
+
+    @property
+    def put_last(self) -> float | None:
+        return self.put_quote.last_price
+
+    @property
+    def put_mid(self) -> float | None:
+        return self.put_quote.mid_price
+
+
+class StrategyEngine:
+    def __init__(
+        self,
+        data_client: MarketDataClient | None = None,
+        option_client: OptionChainClient | None = None,
+        notifier: Notifier | None = None,
+        parameters: StrategyParameters | None = None,
+    ) -> None:
+        self.data_client = data_client or MarketDataClient()
+        self.option_client = option_client or OptionChainClient()
+        self.notifier = notifier or ConsoleNotifier()
+        self.parameters = parameters or StrategyParameters()
+
+    def _select_quote(self, quotes: Sequence[OptionQuote], target_strike: float) -> OptionQuote | None:
+        if not quotes:
+            return None
+        ordered = sorted(quotes, key=lambda q: (abs(q.strike - target_strike), q.strike))
+        for quote in ordered:
+            if quote.price_per_share > 0:
+                return quote
+        return None
+
+    def evaluate(self, ticker: str, parameters: StrategyParameters | None = None) -> List[StrategyResult]:
+        params = parameters or self.parameters
+        market_data = self.data_client.fetch(ticker)
+        valuation_time = market_data.valuation_date
+        spot_price = market_data.spot_price
+        expiries = sorted(self.option_client.list_expiries(ticker))
+
+        filtered_expiries: List[tuple[datetime, int]] = []
+        last_selected_days: int | None = None
+        for expiry in expiries:
+            delta_seconds = (expiry - valuation_time).total_seconds()
+            days = max(0, math.ceil(delta_seconds / 86400))
+            if days < params.min_days or days > params.max_days:
+                continue
+            if params.expiry_step > 0 and last_selected_days is not None:
+                if days - last_selected_days < params.expiry_step:
+                    continue
+            filtered_expiries.append((expiry, days))
+            last_selected_days = days
+
+        results: List[StrategyResult] = []
+        for expiry, days in filtered_expiries:
+            if days == 0:
+                continue
+            chain = self.option_client.fetch_chain(ticker, expiry)
+            target_call_strike = params.call_strike_pct * spot_price
+            call_quote = self._select_quote(chain.calls, target_call_strike)
+            if call_quote is None:
+                continue
+            call_price_per_share = call_quote.price_per_share
+            if call_price_per_share <= 0:
+                continue
+            call_strike = call_quote.strike
+            call_premium = call_price_per_share * params.contract_size * params.call_contracts
+
+            for variation in params.put_strike_variation:
+                put_strike_pct = max(0.01, params.put_strike_pct * (1.0 + variation))
+                target_put_strike = put_strike_pct * spot_price
+                put_quote = self._select_quote(chain.puts, target_put_strike)
+                if put_quote is None:
+                    continue
+                put_price_per_share = put_quote.price_per_share
+                if put_price_per_share <= 0:
+                    continue
+                put_strike = put_quote.strike
+                call_strike_pct = call_strike / spot_price if spot_price > 0 else 0.0
+                put_strike_pct_actual = put_strike / spot_price if spot_price > 0 else 0.0
+                put_premium = put_price_per_share * params.contract_size * params.put_contracts
+
+                net_premium = put_premium - call_premium
+                capital_at_risk = params.put_contracts * params.contract_size * put_strike
+                if capital_at_risk <= 0:
+                    continue
+                annualized_yield = (net_premium / capital_at_risk) * (365.0 / days)
+                shares_short_put = params.put_contracts * params.contract_size
+                breakeven_price = put_strike - net_premium / shares_short_put
+                effective_entry_price = breakeven_price
+
+                implied_values = [
+                    vol
+                    for vol in (call_quote.implied_volatility, put_quote.implied_volatility)
+                    if vol is not None and vol > 0
+                ]
+                implied_volatility = (
+                    sum(implied_values) / len(implied_values) if implied_values else None
+                )
+                if implied_volatility is not None:
+                    if implied_volatility < params.min_volatility:
+                        continue
+                    if implied_volatility > params.max_volatility:
+                        continue
+
+                results.append(
+                    StrategyResult(
+                        ticker=market_data.ticker,
+                        valuation_time=valuation_time,
+                        expiry=expiry,
+                        days_to_expiry=days,
+                        call_strike=call_strike,
+                        put_strike=put_strike,
+                        call_strike_pct=call_strike_pct,
+                        put_strike_pct=put_strike_pct_actual,
+                        call_price_per_share=call_price_per_share,
+                        put_price_per_share=put_price_per_share,
+                        call_premium=call_premium,
+                        put_premium=put_premium,
+                        net_premium=net_premium,
+                        annualized_yield=annualized_yield,
+                        implied_volatility=implied_volatility,
+                        spot_price=market_data.spot_price,
+                        breakeven_price=breakeven_price,
+                        effective_entry_price=effective_entry_price,
+                        capital_at_risk=capital_at_risk,
+                        call_contracts=params.call_contracts,
+                        put_contracts=params.put_contracts,
+                        contract_size=params.contract_size,
+                        call_quote=call_quote,
+                        put_quote=put_quote,
+                    )
+                )
+        results.sort(key=lambda r: r.annualized_yield, reverse=True)
+        return results
+
+    def best_result(self, ticker: str, parameters: StrategyParameters | None = None) -> StrategyResult | None:
+        evaluated = self.evaluate(ticker, parameters)
+        return evaluated[0] if evaluated else None
+
+    def run(self, config: StrategyConfig | None = None) -> List[StrategyResult]:
+        if config is None:
+            tickers = ["AAPL", "MSFT", "GOOGL", "META"]
+            params = self.parameters
+        else:
+            tickers = config.normalized_tickers()
+            params = StrategyParameters(
+                put_strike_pct=config.put_strike_pct,
+                call_strike_pct=config.call_strike_pct,
+                min_days=config.min_days,
+                max_days=config.max_days,
+                expiry_step=config.expiry_step,
+                call_contracts=config.call_to_put_ratio[0],
+                put_contracts=config.call_to_put_ratio[1],
+                contract_size=config.contract_size,
+                risk_free_rate=config.risk_free_rate,
+                min_volatility=config.min_volatility,
+                max_volatility=config.max_volatility,
+                put_strike_variation=tuple(config.put_strike_variation),
+            )
+
+        results: List[StrategyResult] = []
+        for ticker in tickers:
+            try:
+                ticker_results = self.evaluate(ticker, params)
+            except Exception as exc:  # pragma: no cover - defensive
+                self.notifier.notify(f"Failed to evaluate {ticker}: {exc}")
+                continue
+            if ticker_results:
+                best = ticker_results[0]
+                self.notifier.notify(
+                    f"{ticker}: best expiry {best.expiry.date()} with annualized yield {best.annualized_yield:.2%}"
+                )
+                results.append(best)
+        results.sort(key=lambda r: r.annualized_yield, reverse=True)
+        return results

--- a/src/options_trader/volatility.py
+++ b/src/options_trader/volatility.py
@@ -1,0 +1,38 @@
+"""Volatility estimators."""
+from __future__ import annotations
+
+import math
+import statistics
+from dataclasses import dataclass
+from typing import Sequence
+
+TRADING_DAYS_PER_YEAR = 252
+
+
+@dataclass(frozen=True)
+class VolatilityEstimate:
+    annualized: float
+    daily_std: float
+
+
+def historical_volatility(
+    prices: Sequence[float],
+    trading_days: int = TRADING_DAYS_PER_YEAR,
+) -> VolatilityEstimate:
+    """Estimate historical volatility from a sequence of prices."""
+
+    if len(prices) < 2:
+        raise ValueError("Need at least two price points to estimate volatility.")
+
+    log_returns = []
+    for previous, current in zip(prices, prices[1:]):
+        if previous <= 0 or current <= 0:
+            raise ValueError("Prices must be positive to compute log returns.")
+        log_returns.append(math.log(current / previous))
+
+    if len(log_returns) < 2:
+        daily_std = 0.0
+    else:
+        daily_std = float(statistics.stdev(log_returns))
+    annualized = daily_std * math.sqrt(trading_days)
+    return VolatilityEstimate(annualized=annualized, daily_std=daily_std)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Test configuration to ensure the package is importable."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,158 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from options_trader.data import MarketData, MarketDataClient, OptionChainSlice, OptionQuote
+from options_trader.strategy import StrategyEngine, StrategyParameters
+
+
+class DummyMarketDataClient(MarketDataClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.valuation_time = datetime(2024, 1, 2, tzinfo=timezone.utc)
+        prices = [141 + i for i in range(10)]
+        self._data = MarketData(
+            ticker="ABC",
+            spot_price=float(prices[-1]),
+            valuation_date=self.valuation_time,
+            historical_prices=prices,
+        )
+
+    def fetch(self, ticker: str) -> MarketData:  # type: ignore[override]
+        return MarketData(
+            ticker=ticker,
+            spot_price=self._data.spot_price,
+            valuation_date=self.valuation_time,
+            historical_prices=list(self._data.historical_prices),
+        )
+
+
+class DummyOptionChainClient:
+    def __init__(self, valuation_time: datetime) -> None:
+        self.valuation_time = valuation_time
+        self.expiry_1 = valuation_time + timedelta(days=120)
+        self.expiry_2 = valuation_time + timedelta(days=150)
+
+    def list_expiries(self, ticker: str):  # type: ignore[override]
+        return [self.expiry_1, self.expiry_2]
+
+    def fetch_chain(self, ticker: str, expiry: datetime):  # type: ignore[override]
+        if expiry == self.expiry_1:
+            calls = [
+                OptionQuote(
+                    ticker=ticker,
+                    expiry=expiry,
+                    strike=150.0,
+                    option_type="call",
+                    bid=5.5,
+                    ask=6.5,
+                    last_price=6.0,
+                    implied_volatility=0.24,
+                )
+            ]
+            puts = [
+                OptionQuote(
+                    ticker=ticker,
+                    expiry=expiry,
+                    strike=135.0,
+                    option_type="put",
+                    bid=9.5,
+                    ask=10.5,
+                    last_price=10.0,
+                    implied_volatility=0.28,
+                ),
+                OptionQuote(
+                    ticker=ticker,
+                    expiry=expiry,
+                    strike=130.0,
+                    option_type="put",
+                    bid=7.0,
+                    ask=7.6,
+                    last_price=7.3,
+                    implied_volatility=0.27,
+                ),
+            ]
+        else:
+            calls = [
+                OptionQuote(
+                    ticker=ticker,
+                    expiry=expiry,
+                    strike=150.0,
+                    option_type="call",
+                    bid=4.8,
+                    ask=5.2,
+                    last_price=5.0,
+                    implied_volatility=0.22,
+                )
+            ]
+            puts = [
+                OptionQuote(
+                    ticker=ticker,
+                    expiry=expiry,
+                    strike=135.0,
+                    option_type="put",
+                    bid=8.0,
+                    ask=8.6,
+                    last_price=8.3,
+                    implied_volatility=0.25,
+                ),
+            ]
+
+        return OptionChainSlice(ticker=ticker, expiry=expiry, calls=calls, puts=puts)
+
+
+def test_engine_uses_live_option_quotes():
+    market_client = DummyMarketDataClient()
+    option_client = DummyOptionChainClient(market_client.valuation_time)
+    params = StrategyParameters(
+        min_days=100,
+        max_days=140,
+        expiry_step=20,
+        call_strike_pct=1.0,
+        put_strike_pct=0.9,
+        put_strike_variation=(0.0,),
+        min_volatility=0.1,
+        max_volatility=0.4,
+    )
+    engine = StrategyEngine(
+        data_client=market_client, option_client=option_client, parameters=params
+    )
+
+    results = engine.evaluate("ABC")
+    assert len(results) == 1
+    result = results[0]
+
+    assert result.call_strike == pytest.approx(150.0)
+    assert result.put_strike == pytest.approx(135.0)
+    assert result.call_price_per_share == pytest.approx(6.0)
+    assert result.put_price_per_share == pytest.approx(10.0)
+    assert result.call_premium == pytest.approx(6.0 * params.contract_size * params.call_contracts)
+    assert result.put_premium == pytest.approx(10.0 * params.contract_size * params.put_contracts)
+    assert result.net_premium == pytest.approx(result.put_premium - result.call_premium)
+    assert result.capital_at_risk == pytest.approx(135.0 * params.contract_size * params.put_contracts)
+    assert result.call_strike_pct == pytest.approx(1.0)
+    assert result.put_strike_pct == pytest.approx(0.9)
+    assert result.implied_volatility == pytest.approx((0.24 + 0.28) / 2)
+
+
+def test_best_result_prefers_highest_yield():
+    market_client = DummyMarketDataClient()
+    option_client = DummyOptionChainClient(market_client.valuation_time)
+    params = StrategyParameters(
+        min_days=100,
+        max_days=200,
+        expiry_step=10,
+        put_strike_variation=(0.0,),
+        min_volatility=0.1,
+        max_volatility=0.4,
+    )
+    engine = StrategyEngine(
+        data_client=market_client, option_client=option_client, parameters=params
+    )
+
+    results = engine.evaluate("ABC")
+    assert len(results) == 2
+
+    best = engine.best_result("ABC")
+    assert best is not None
+    assert best.annualized_yield == max(r.annualized_yield for r in results)


### PR DESCRIPTION
## Summary
- integrate Yahoo Finance option chain downloads and quote selection into the strategy engine so premiums, implied vols, and metrics use live market data
- extend the CLI and documentation with default high-conviction tickers, daily scheduling (e.g. 16:30 GST), and refreshed reporting output for per-share premiums and bid/ask context
- update configuration, dependencies, and unit tests to exercise the new data clients and ensure highest-yield selection works with real quote inputs

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cab8d224948331a57f2f3493525567